### PR TITLE
Don't allow extending a protected callback.

### DIFF
--- a/src/Jimple.js
+++ b/src/Jimple.js
@@ -71,9 +71,10 @@ class Jimple {
     extend (key, fn) {
          checkDefined(this, key);
          let originalItem = this.items[key]; 
-         if (!isFunction(originalItem)) {
+         if (!isFunction(originalItem) || this.protected.has(originalItem)) {
              throw new Error(`Identifier '${key}' does not contain a service definition`);
          }
+         
          if (!isFunction(fn)) {
              throw new Error(`The 'new' service definition for '${key}' is not a invokable object.`);
          }

--- a/test/JimpleTest.js
+++ b/test/JimpleTest.js
@@ -256,6 +256,15 @@ describe("Jimple", function() {
                 jimple.extend("age", function(){});
             }).to.throwException();
         });
+	   it("should throw an error on protected key", function() {
+            var jimple = new Jimple();
+            jimple.set("theAnswer", jimple.protect(function () {
+                return 42;
+            }));
+            expect(function() {
+                jimple.extend("theAnswer", function(){ return 41; });
+            }).to.throwException();
+        });
        it("should throw an error on invalid callable", function() {
             var jimple = new Jimple();
             jimple.set("age", function() { return 19; });


### PR DESCRIPTION
A protected callback is supposed to act like a parameter. It should not be possible to extend such a function because te current code would call it with `container` as first argument which beats the purpose of 'protecting' it in the first place.