### PR TITLE
Fix #72

### DIFF
--- a/src/Jimple.js
+++ b/src/Jimple.js
@@ -7,11 +7,7 @@ function assert(ok, message) {
 }
 
 function isFunction(fn) {
-    return Object.prototype.toString.call(fn) === "[object Function]" && fn.constructor.name === "Function";
-}
-
-function isAsyncFunction(fn) {
-    return Object.prototype.toString.call(fn) === "[object AsyncFunction]" && fn.constructor.name === "AsyncFunction";
+    return (typeof === 'function');
 }
 
 function isPlainObject(value) {
@@ -66,7 +62,7 @@ class Jimple {
         checkDefined(this, key);
         let item = this._items[key];
         let obj;
-        if (isFunction(item) || isAsyncFunction(item)) {
+        if (isFunction(item)) {
             if (this._protected.has(item)) {
                 obj = item;
             } else if (this._instances.has(item)) {


### PR DESCRIPTION
It turns out testing if an async function is an async function is a bad idea.
Since an async function should be treated like a function (returning a Promise, but ... it's a function)
What about using this test to know if a function is a function ? (It is compatible with IE11)